### PR TITLE
Fix zip file cleanup path in Redis utils

### DIFF
--- a/examples/vector_databases/redis/nbutils.py
+++ b/examples/vector_databases/redis/nbutils.py
@@ -30,7 +30,7 @@ def download_wikipedia_data(
             zip_ref.extractall(data_path)
 
         # Remove the zip file
-        os.remove('vector_database_wikipedia_articles_embedded.zip')
+        os.remove(zip_file_path)
         print(f"File downloaded to {data_path}")
 
 


### PR DESCRIPTION
## Summary
- fix zip removal path in Redis vector database utility

## Testing
- `python -m py_compile examples/vector_databases/redis/nbutils.py`

------
https://chatgpt.com/codex/tasks/task_e_6847d52af8d8832aa913b529d3d61764