### PR TITLE
Fix multi-agent tag typo

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -30,7 +30,7 @@
     - agents-sdk
     - functions
     - responses
-    - mutli-agent-collaboration
+    - multi-agent-collaboration
 
 - title: o3/o4-mini Function Calling Guide
   path: examples/o-series/o3o4-mini_prompting_guide.ipynb


### PR DESCRIPTION
## Summary
- correct typo in registry tag from `mutli-agent-collaboration` to `multi-agent-collaboration`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d858aaac832aa66d01e8655e6a6d