### PR TITLE
Fix root directory resolution for multi-agent portfolio

### DIFF
--- a/examples/agents_sdk/multi-agent-portfolio-collaboration/utils.py
+++ b/examples/agents_sdk/multi-agent-portfolio-collaboration/utils.py
@@ -21,7 +21,8 @@ DISCLAIMER = (
 # Paths
 # ---------------------------------------------------------------------------
 
-ROOT_DIR: Path = Path(__file__).resolve().parent  # repository root
+# The repository root (../../.. from this file)
+ROOT_DIR: Path = Path(__file__).resolve().parents[3]
 
 
 def repo_path(rel: str | Path) -> Path:


### PR DESCRIPTION
## Summary
- fix incorrect ROOT_DIR path in the multi-agent portfolio example

## Testing
- `python -m py_compile examples/agents_sdk/multi-agent-portfolio-collaboration/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d877bf90832a9e3aafa64d58affc