### PR TITLE
Fix typo in CONTRIBUTING heading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing the the cookbook
+# Contributing to the cookbook
 
 The OpenAI Cookbook is a collection of useful patterns and examples of working with the OpenAI platform, provided as a community resource.
 


### PR DESCRIPTION
## Summary
- correct initial heading in `CONTRIBUTING.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847d89b5960832ab039849684e03d64