### PR TITLE
Fix logging warning in parallel processor

### DIFF
--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -253,7 +253,7 @@ async def process_api_requests_from_file(
                     )
                     await asyncio.sleep(remaining_seconds_to_pause)
                     # ^e.g., if pause is 15 seconds and final limit was hit 5 seconds ago
-                    logging.warn(
+                    logging.warning(
                         f"Pausing to cool down until {time.ctime(status_tracker.time_of_last_rate_limit_error + seconds_to_pause_after_rate_limit_error)}"
                     )
 


### PR DESCRIPTION
## Summary
- fix deprecated `logging.warn` call in `api_request_parallel_processor.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847def213e8832aabdcb465dce2fe4d